### PR TITLE
Debug ServivewithRouteForm submission issue

### DIFF
--- a/servicewithrouteForm.vue
+++ b/servicewithrouteForm.vue
@@ -766,6 +766,8 @@ const onSubmitForApproval = async () => {
     return
   }
   
+  loading.value = true
+  
   try {
     // Manually sync route data from RouteForm component
     if (routeFormRef.value && routeFormRef.value.formData) {
@@ -800,19 +802,21 @@ const onSubmitForApproval = async () => {
       console.log('Emitting form data to parent component')
       emit('submit', approvalRequest)
     } else {
-    // Submit to approval system (use the correct backend endpoint)
-    await axios.post('/api/service-approval-requests', approvalRequest)
-    
-    // Show success message
-    alert(`Service request "${generalInfo.name}" submitted for approval successfully!`)
-    
-    // Redirect to service requests page
-    router.push('/service-requests')
+      // Submit to approval system (use the correct backend endpoint)
+      await axios.post('/api/service-approval-requests', approvalRequest)
+      
+      // Show success message
+      alert(`Service request "${generalInfo.name}" submitted for approval successfully!`)
+      
+      // Redirect to service requests page
+      router.push('/service-requests')
     }
     
   } catch (error: any) {
     console.error('Failed to submit approval request:', error)
     alert(`Failed to submit approval request: ${error.response?.data?.message || error.message}`)
+  } finally {
+    loading.value = false
   }
 }
 </script>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add loading state management to `onSubmitForApproval` to enable form submission and prevent multiple requests.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The submit button was disabled based on a `loading` state, but this state was never updated during the submission process. This prevented the form from being submitted and lacked visual feedback. The fix ensures `loading` is set to `true` at the start of submission and `false` in a `finally` block, enabling submission, preventing multiple clicks, and providing proper UI feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d89a50c-dfd4-43ad-833f-307ac9cbdd0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d89a50c-dfd4-43ad-833f-307ac9cbdd0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>